### PR TITLE
set java_home

### DIFF
--- a/templates/tomcat.init.erb
+++ b/templates/tomcat.init.erb
@@ -16,7 +16,7 @@
 
 ## Source function library.
 #. /etc/rc.d/init.d/functions
-source /etc/profile.d/java.sh
+JAVA_HOME=/etc/alternatives/jre
 PATH=$JAVA_HOME/bin:$PATH
 export PATH
 TOMCAT_HOME=<%= scope.lookupvar('install_dir') %>/tomcat


### PR DESCRIPTION
Remove dependency on /etc/profile.d/java.sh (not present on RHEL7-based machines)