### PR TITLE
Tomcat8suport

### DIFF
--- a/templates/server.xml.header
+++ b/templates/server.xml.header
@@ -13,7 +13,9 @@ Managed by puppet - do not modify
   <!--APR library loader. Documentation at /docs/apr.html -->
   <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
   <!--Initialize Jasper prior to webapps are loaded. Documentation at /docs/jasper-howto.html -->
+  <% if Gem::Version.new(@version) > Gem::Version.new('7.0.0') -%>
   <Listener className="org.apache.catalina.core.JasperListener" />
+  <% end -%>
   <!-- Prevent memory leaks due to use of particular java/javax APIs-->
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
   <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />

--- a/templates/server.xml.header
+++ b/templates/server.xml.header
@@ -13,7 +13,7 @@ Managed by puppet - do not modify
   <!--APR library loader. Documentation at /docs/apr.html -->
   <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
   <!--Initialize Jasper prior to webapps are loaded. Documentation at /docs/jasper-howto.html -->
-  <% if Gem::Version.new(@version) > Gem::Version.new('7.0.0') -%>
+  <% if Gem::Version.new(@version) < Gem::Version.new('8.0.0') -%>
   <Listener className="org.apache.catalina.core.JasperListener" />
   <% end -%>
   <!-- Prevent memory leaks due to use of particular java/javax APIs-->


### PR DESCRIPTION
Created a clause that includes JasperListener from server.xml.header in the case that the version number is less than 8.0.0. Otherwise exclude it.

my puppet test case was this:

  class { 'tomcat':
    version => '8.0.28',
    static_url => 'http://apache.mirror.gtcomm.net/tomcat/tomcat-8/v8.0.28/bin',
  }

and I would get this in the log:

java.lang.ClassNotFoundException: org.apache.catalina.core.java.lang.ClassNotFoundException: org.apache.catalina.core.JasperListener

I googled for this problem and found this page:

https://confluence.atlassian.com/display/STASHKB/Stash+does+not+start+-+After+upgrade+due+to+ClassNotFoundException+org.apache.catalina.core.JasperListener

So it made me think that I might be able to solve this simply.

And it looks like it's worked.

With the test case above tomcat starts.

Who know what else might not work in version 8. but hey, knock of one bug at a time yeah?

David Thornton.

Test results:

$ bundle exec rake test
---> syntax:manifests
---> syntax:templates
---> syntax:hiera:yaml
metadata-json-lint metadata.json
metadata-json-lint metadata.json
Notice: Preparing to install into /tmp/evenup-tomcat/spec/fixtures/modules ...
Notice: Downloading from https://forgeapi.puppetlabs.com ...
Notice: Installing -- do not interrupt ...
/tmp/evenup-tomcat/spec/fixtures/modules
└── evenup-artifactory (v2.0.0)
Notice: Preparing to install into /tmp/evenup-tomcat/spec/fixtures/modules ...
Notice: Downloading from https://forgeapi.puppetlabs.com ...
Notice: Installing -- do not interrupt ...
/tmp/evenup-tomcat/spec/fixtures/modules
└── puppetlabs-concat (v1.1.0)
Notice: Preparing to install into /tmp/evenup-tomcat/spec/fixtures/modules ...
Notice: Downloading from https://forgeapi.puppetlabs.com ...
Notice: Installing -- do not interrupt ...
/tmp/evenup-tomcat/spec/fixtures/modules
└── puppetlabs-java (v1.0.0)
Notice: Preparing to install into /tmp/evenup-tomcat/spec/fixtures/modules ...
Notice: Downloading from https://forgeapi.puppetlabs.com ...
Notice: Installing -- do not interrupt ...
/tmp/evenup-tomcat/spec/fixtures/modules
└── nanliu-staging (v1.0.3)
Notice: Preparing to install into /tmp/evenup-tomcat/spec/fixtures/modules ...
Notice: Downloading from https://forgeapi.puppetlabs.com ...
Notice: Installing -- do not interrupt ...
/tmp/evenup-tomcat/spec/fixtures/modules
└── puppetlabs-stdlib (v4.9.0)
/usr/bin/ruby1.9.1 -I/var/lib/gems/1.9.1/gems/rspec-core-3.1.7/lib:/var/lib/gems/1.9.1/gems/rspec-support-3.1.2/lib /var/lib/gems/1.9.1/gems/rspec-core-3.1.7/exe/rspec --pattern spec/{classes,defines,unit,functions,hosts,integration}/**/*_spec.rb --color
..............................................

Finished in 4.75 seconds (files took 0.81558 seconds to load)
46 examples, 0 failures
$

$ bundle exec rake acceptance
/usr/bin/ruby1.9.1 -I/var/lib/gems/1.9.1/gems/rspec-core-3.1.7/lib:/var/lib/gems/1.9.1/gems/rspec-support-3.1.2/lib /var/lib/gems/1.9.1/gems/rspec-core-3.1.7/exe/rspec spec/acceptance
/var/lib/gems/1.9.1/gems/beaker-rspec-5.3.0/lib/beaker-rspec/helpers/serverspec.rb:43: warning: already initialized constant VALID_OPTIONS_KEYS
/var/lib/gems/1.9.1/gems/beaker-2.27.0/lib/beaker/options/hosts_file_parser.rb:23:in `parse_hosts_file': Host file '/tmp/evenup-tomcat/spec/acceptance/nodesets/default.yml' does not exist! (ArgumentError)
        from /var/lib/gems/1.9.1/gems/beaker-2.27.0/lib/beaker/options/parser.rb:195:in`parse_args'
        from /var/lib/gems/1.9.1/gems/beaker-rspec-5.3.0/lib/beaker-rspec/beaker_shim.rb:58:in `setup'
        from /var/lib/gems/1.9.1/gems/beaker-rspec-5.3.0/lib/beaker-rspec/spec_helper.rb:45:in`block in <top (required)>'
        from /var/lib/gems/1.9.1/gems/rspec-core-3.1.7/lib/rspec/core.rb:81:in `configure'
        from /var/lib/gems/1.9.1/gems/beaker-rspec-5.3.0/lib/beaker-rspec/spec_helper.rb:5:in`<top (required)>'
        from /tmp/evenup-tomcat/spec/spec_helper_acceptance.rb:1:in `require'
        from /tmp/evenup-tomcat/spec/spec_helper_acceptance.rb:1:in`<top (required)>'
        from /tmp/evenup-tomcat/spec/acceptance/class_spec.rb:1:in `require'
        from /tmp/evenup-tomcat/spec/acceptance/class_spec.rb:1:in`<top (required)>'
        from /var/lib/gems/1.9.1/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `load'
        from /var/lib/gems/1.9.1/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in`block in load_spec_files'
        from /var/lib/gems/1.9.1/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `each'
        from /var/lib/gems/1.9.1/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in`load_spec_files'
        from /var/lib/gems/1.9.1/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:96:in `setup'
        from /var/lib/gems/1.9.1/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:84:in`run'
        from /var/lib/gems/1.9.1/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:69:in `run'
        from /var/lib/gems/1.9.1/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:37:in`invoke'
        from /var/lib/gems/1.9.1/gems/rspec-core-3.1.7/exe/rspec:4:in `<main>'
/usr/bin/ruby1.9.1 -I/var/lib/gems/1.9.1/gems/rspec-core-3.1.7/lib:/var/lib/gems/1.9.1/gems/rspec-support-3.1.2/lib /var/lib/gems/1.9.1/gems/rspec-core-3.1.7/exe/rspec spec/acceptance failed
$
